### PR TITLE
Update firefox-profile to 0.4.6 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ export.config = {
   // ...
   services: ['firefox-profile'],
   firefoxProfile: {
-      extensions: ['/path/to/extensionA.xpi', '/path/to/extensionB.xpi'],
-      'browser.startup.homepage': 'http://webdriver.io'
+    extensions: [
+      '/path/to/extensionA.xpi', // path to .xpi file
+      '/path/to/extensionB' // or path to unpacked Firefox extension
+    ],
+    'browser.startup.homepage': 'http://webdriver.io'
   },
   // ...
 };

--- a/package.json
+++ b/package.json
@@ -31,29 +31,30 @@
     "url": "https://github.com/webdriverio/wdio-firefox-profile-service/issues"
   },
   "dependencies": {
-    "firefox-profile": "^0.3.12"
+    "firefox-profile": "^0.4.6"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.7.2",
-    "babel-eslint": "^6.0.0",
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.21.0",
+    "babel-eslint": "^7.1.1",
     "babel-plugin-array-includes": "^2.0.3",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-register": "^6.7.2",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-register": "^6.18.0",
     "chai": "^3.5.0",
-    "eslint": "^2.5.1",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-standard": "^1.3.2",
-    "grunt": "^0.4.5",
+    "eslint": "^3.13.1",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "^2.0.1",
+    "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",
-    "grunt-bump": "^0.7.0",
+    "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-eslint": "^18.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-npm": "0.0.2",
-    "load-grunt-tasks": "^3.4.1",
-    "wdio-mocha-framework": "^0.2.12",
-    "webdriverio": "^4.0.6"
+    "load-grunt-tasks": "^3.5.2",
+    "wdio-mocha-framework": "^0.5.8",
+    "webdriverio": "^4.6.1"
   }
 }


### PR DESCRIPTION
Changes made:
- firefox-profile updated to 0.4.6 version. Now it allows installing WebExtensions. Unpacked extension also can be installed;
- other dependencies updated;
- fixed https://github.com/webdriverio/wdio-firefox-profile-service/issues/3;
- readme updated.